### PR TITLE
Fix CLCD init sequence for WS0010/RS0010 displays

### DIFF
--- a/mios/mios_clcd.inc
+++ b/mios/mios_clcd.inc
@@ -98,18 +98,6 @@ MIOS_CLCD_Init_Cmds_4Bit
 	clrf	MIOS_CLCD_LAT_D
 	movlw	1			; 1 mS delayed toggle
 	rcall	MIOS_CLCD_Strobe_DelayToggle			; DB7-DB4: 0000 (N/F)
-
-	movlw	1			; 1 mS delayed toggle
-	rcall	MIOS_CLCD_Strobe_DelayToggle			; DB7-DB4: 0000
-
-	movlw	0x10
-	movwf	MIOS_CLCD_LAT_D
-	movlw	1			; 1 mS delayed toggle
-	rcall	MIOS_CLCD_Strobe_DelayToggle			; DB7-DB4: 0001
-
-	clrf	MIOS_CLCD_LAT_D
-	movlw	1			; 1 mS delayed toggle
-	rcall	MIOS_CLCD_Strobe_DelayToggle			; DB7-DB4: 0000
 MIOS_CLCD_Init_Cmds_No4Bit
 
 	movlw	0x08			; Display Off


### PR DESCRIPTION
Hi! 😄 

Recently I've been building a MB6582 and wanted to use a modern Raystar OLED (part number REC002004AYPP5N00000).

This display doesn't work out-of-the-box unless the user jumpers the MB6582 PCB to use 8-bit mode, and then selects the Custom LCD driver by setting the PIC ID bits (see forum thread: http://midibox.org/forums/topic/20408-midibox-mb6582-newhaven-oled-finally-working-d/?page=1).

I thought I'd try to figure out why this display doesn't work with the standard 4-bit CLCD driver, and found that because an odd number of nybbles is sent to the controller, it doesn't function.

I compared the code with page 46 of the HD44780 datasheet and found that the init sequence doesn't quite match up. Obviously this has not been a problem for older LCDs as MIDIbox has existed for many years now and people have been using this startup code for a long time! But perhaps modern screens are fussier about the initialization:

![image](https://user-images.githubusercontent.com/5890747/88379035-19385000-cd9a-11ea-9552-28bf65bf9b0f.png)

This patch simply removes the extra nybble and duplicated Display Off command, and the OLED is now 100% fully functional:

![midibox](https://user-images.githubusercontent.com/5890747/88377659-7979c280-cd97-11ea-9b04-e3073227c624.JPG)

The only issue is I don't have any older traditional LCD screens to double-check that this change doesn't break them - I was hoping you might be able to test this patch with some of your MIDIbox builds to verify the LCDs still work.

Thanks! (and also thankyou so much for the MIDIbox project, I've been wanting to build a SID synth for many years now and although I'm late to the party, I'm really enjoying it so far! 😃 )